### PR TITLE
Fix numpy scalar hierarchy

### DIFF
--- a/numpy-stubs/__init__.pyi
+++ b/numpy-stubs/__init__.pyi
@@ -26,15 +26,15 @@ from pandas import Series
 
 _T = TypeVar("_T")
 
-# dtype is the base class of all the types that an ndarray can have
-class dtype:
+# generic is the base class of all the types that an ndarray can have
+class generic:
     @property
     def type(self: _T) -> Type[_T]: ...
     def astype(self, dtype: Type[_DType]) -> _DType: ...
 
 _Number = TypeVar("_Number", bound=number)
 
-class number(dtype):
+class number(generic):
     def copy(self: _Number) -> _Number: ...
 
 # a smaller-bit integer can act like a bigger integer in the sense that if you add an int16 and an
@@ -49,13 +49,12 @@ class int32(int64): ...
 class int16(int32): ...
 class int8(int16): ...
 class bool_(int8): ...
-class str_(dtype, str): ...
-
-_dtype = dtype
+class str_(generic, str): ...
+class object_(generic): ...
 
 _DType = TypeVar("_DType", bool_, float32, float64, int8, int16, int32, int64, str_, covariant=True)
 _DType2 = TypeVar("_DType2", bool_, float32, float64, int8, int16, int32, int64, str_)
-_DTypeObj = TypeVar("_DTypeObj", bound=Union[dtype, int, float])
+_DTypeObj = TypeVar("_DTypeObj", bound=Union[generic, int, float])
 _ShapeType = Union[int, Tuple[int, ...], List[int]]
 _AxesType = Union[int, Tuple[int, ...], List[int]]
 _InterpolationType = Literal["linear", "lower", "higher", "midpoint", "nearest"]
@@ -74,6 +73,16 @@ _IntObj = TypeVar("_IntObj", bound=Union[integer, int])
 _BoolObj = TypeVar("_BoolObj", bound=Union[bool_, bool])
 
 _NestedList = Union[List[_T], List[List[_T]], List[List[List[_T]]], List[List[List[List[_T]]]]]
+
+class dtype(Generic[_DType]):
+    @overload
+    def __init__(self: dtype[_DType], obj: Type[_DType]) -> None: ...
+    @overload
+    def __init__(self, obj: str) -> None: ...
+    @property
+    def type(self) -> Type[_DType]: ...
+
+_dtype = dtype
 
 class ndarray(Generic[_DType]):
     """

--- a/numpy-stubs/__init__.pyi
+++ b/numpy-stubs/__init__.pyi
@@ -28,6 +28,8 @@ _T = TypeVar("_T")
 
 # generic is the base class of all the types that an ndarray can have
 class generic:
+    @property
+    def dtype(self: _DTypeObj) -> _dtype[_DTypeObj]: ...
     def astype(self, dtype: Type[_DType]) -> _DType: ...
 
 _Number = TypeVar("_Number", bound=number)
@@ -72,13 +74,13 @@ _BoolObj = TypeVar("_BoolObj", bound=Union[bool_, bool])
 
 _NestedList = Union[List[_T], List[List[_T]], List[List[List[_T]]], List[List[List[List[_T]]]]]
 
-class dtype(Generic[_DType]):
+class dtype(Generic[_DTypeObj]):
     @overload
-    def __init__(self: dtype[_DType], obj: Type[_DType]) -> None: ...
+    def __init__(self: dtype[_DTypeObj], obj: Type[_DTypeObj]) -> None: ...
     @overload
     def __init__(self, obj: str) -> None: ...
     @property
-    def type(self) -> Type[_DType]: ...
+    def type(self) -> Type[_DTypeObj]: ...
 
 _dtype = dtype
 

--- a/numpy-stubs/__init__.pyi
+++ b/numpy-stubs/__init__.pyi
@@ -28,8 +28,6 @@ _T = TypeVar("_T")
 
 # generic is the base class of all the types that an ndarray can have
 class generic:
-    @property
-    def type(self: _T) -> Type[_T]: ...
     def astype(self, dtype: Type[_DType]) -> _DType: ...
 
 _Number = TypeVar("_Number", bound=number)
@@ -92,7 +90,7 @@ class ndarray(Generic[_DType]):
     #
     # Array-like structures attributes
     #
-    dtype: _DType
+    dtype: _dtype[_DType]
     size: int
     ndim: int
     shape: Tuple[int, ...]

--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -39,7 +39,7 @@ _ColSubsetType = Union[Series, DataFrame, List[_str], _str, _np.ndarray[_np.str_
 
 _FunctionLike = Union[_str, Callable]
 
-_TypeLike = Union[_str, _np.dtype, Type[float], Type[_str]]
+_TypeLike = Union[_str, _np.dtype, Type[_np.generic], Type[float], Type[_str]]
 
 class DataFrame:
     def __init__(

--- a/tests/numpy_test.py
+++ b/tests/numpy_test.py
@@ -134,3 +134,10 @@ def test_where() -> None:
     h2: np.ndarray[np.float64] = np.where(True, 2.0, 3)
     i: np.ndarray[np.int64] = np.where(c == 2, c, 3)
     j: np.ndarray[np.int32] = np.where(c == 2, 2, d)
+
+
+def test_dtype() -> None:
+    f: np.dtype[np.int16] = np.dtype(np.int16)
+    g: np.dtype[np.int32] = np.dtype("int32")
+    assert issubclass(f.type, np.generic)
+    assert issubclass(g.type, np.generic)

--- a/tests/numpy_test.py
+++ b/tests/numpy_test.py
@@ -141,3 +141,6 @@ def test_dtype() -> None:
     g: np.dtype[np.int32] = np.dtype("int32")
     assert issubclass(f.type, np.generic)
     assert issubclass(g.type, np.generic)
+    h: np.int16 = np.int16(3)
+    assert isinstance(h.dtype, np.dtype)
+    assert h.dtype.type is np.int16


### PR DESCRIPTION
`np.dtype` is *not* the base class of all scalar types. It is `np.generic`.

The fix caused surprisingly few problems.