### PR TITLE
Add `empty` property for pandas.DataFrame

### DIFF
--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -99,6 +99,8 @@ class DataFrame:
     # this function is deprecated:
     @property
     def values(self) -> _np.ndarray: ...
+    @property
+    def empty(self) -> bool: ...
     #
     # methods
     @overload


### PR DESCRIPTION
The title is self-explanatory. We're missing this property there.