### PR TITLE
Allow DataFrame.sort_values by a single column name

### DIFF
--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -274,12 +274,16 @@ class DataFrame:
     def sort_index(self, axis: _AxisType) -> DataFrame: ...
     @overload
     def sort_values(
-        self, by: List[_str], inplace: Literal[True], axis: _AxisType = ..., ascending: bool = ...
+        self,
+        by: Union[_str, List[_str]],
+        inplace: Literal[True],
+        axis: _AxisType = ...,
+        ascending: bool = ...,
     ) -> None: ...
     @overload
     def sort_values(
         self,
-        by: List[_str],
+        by: Union[_str, List[_str]],
         inplace: Optional[Literal[False]] = ...,
         axis: _AxisType = ...,
         ascending: bool = ...,

--- a/tests/pandas_test.py
+++ b/tests/pandas_test.py
@@ -141,3 +141,8 @@ def test_iterrows() -> None:
     for_variable: Tuple[Optional[Hashable], pd.Series]
     for for_variable in a.iterrows():
         pass
+
+
+def test_frame_sort_values() -> None:
+    a.sort_values(by="a")
+    a.sort_values(by="a", inplace=True)


### PR DESCRIPTION
according to the documentation, by= can be a str or a list of str