### PR TITLE
Test with python 3.9 instead of 3.8

### DIFF
--- a/.github/workflows/test_correctness.yml
+++ b/.github/workflows/test_correctness.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.8]
+        python-version: [3.6, 3.9]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/test_correctness.yml
+++ b/.github/workflows/test_correctness.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Install pytest and dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest numpy pandas matplotlib
+        pip install pytest numpy pandas matplotlib kiwisolver>=1.3.1
     - name: Test with pytest
       run: |
         python -m pytest -vv tests/


### PR DESCRIPTION
This way we're testing on the oldest still supported (3.6) and the newest.