### PR TITLE
Add pd.read_parquet

### DIFF
--- a/pandas-stubs/__init__.pyi
+++ b/pandas-stubs/__init__.pyi
@@ -80,7 +80,6 @@ def read_parquet(
     path: Union[str, Path, IO],
     engine: Literal["auto", "pyarrow", "fastparquet"] = ...,
     columns: Optional[List[str]] = ...,
-    use_nullable_dtypes: bool = ...,
     **kwargs: Any,
 ) -> DataFrame: ...
 def read_csv(

--- a/pandas-stubs/__init__.pyi
+++ b/pandas-stubs/__init__.pyi
@@ -76,6 +76,13 @@ def merge(
     right_index: bool = ...,
     how: str = ...,
 ) -> DataFrame: ...
+def read_parquet(
+    path: Union[str, Path, IO],
+    engine: Literal["auto", "pyarrow", "fastparquet"] = ...,
+    columns: Optional[List[str]] = ...,
+    use_nullable_dtypes: bool = ...,
+    **kwargs: Any,
+) -> DataFrame: ...
 def read_csv(
     filepath_or_buffer: Union[str, Path, IO],
     sep: str = ...,

--- a/tests/pandas_test.py
+++ b/tests/pandas_test.py
@@ -282,7 +282,7 @@ def test_frame_replace() -> None:
 #     filename = str(tmp_path / "data.parq")
 #     df = pd.DataFrame([[1, 2], [3, 4]], columns=["a", "b"])
 #     df.to_parquet(filename, engine="auto", compression=None, index=True, partition_cols=["a"])
-#     df: pd.DataFrame = pd.read_parquet(filename, engine="auto", columns=["a", "b"], use_nullable_dtypes=False)
+#     df: pd.DataFrame = pd.read_parquet(filename, engine="auto", columns=["a", "b"])
 
 
 def test_series_rank() -> None:

--- a/tests/pandas_test.py
+++ b/tests/pandas_test.py
@@ -278,10 +278,11 @@ def test_frame_replace() -> None:
 
 
 # Uncomment once either pyarrow or fastparquet supports Python 3.9
-# def test_to_parquet(tmp_path: Path) -> None:
+# def test_to_parquet_and_read_parquet(tmp_path: Path) -> None:
 #     filename = str(tmp_path / "data.parq")
 #     df = pd.DataFrame([[1, 2], [3, 4]], columns=["a", "b"])
 #     df.to_parquet(filename, engine="auto", compression=None, index=True, partition_cols=["a"])
+#     df: pd.DataFrame = pd.read_parquet(filename, engine="auto", columns=["a", "b"], use_nullable_dtypes=False)
 
 
 def test_series_rank() -> None:


### PR DESCRIPTION
I have updated the commented out test added by #192 

I did not include the `use_nullable_dtypes` parameter as it was added in Pandas 1.2.0 and data-science-types resolves Pandas to 1.1.4 (on my machine) using a clean Python 3.8.1 venv created by pyenv