### PR TITLE
Add project URLs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,11 @@ gen_pyi()
 setup(
     name="data-science-types",
     version="0.3.0.dev1",
+    url="https://github.com/predictive-analytics-lab/data-science-types",
+    project_urls={
+        "Bug Tracker": "https://github.com/predictive-analytics-lab/data-science-types/issues/",
+        "Source Code": "https://github.com/predictive-analytics-lab/data-science-types",
+    },
     author="PAL",
     description="Type stubs for Python machine learning libraries",
     license="Apache License 2.0",


### PR DESCRIPTION
Probably want to have links to this repo from the [pypi page](https://pypi.org/project/data-science-types/)